### PR TITLE
[SERV-1141] Update workflow to use PAT

### DIFF
--- a/.github/workflows/update-go-version.yml
+++ b/.github/workflows/update-go-version.yml
@@ -87,4 +87,4 @@ jobs:
         if: ${{ steps.check-update.outputs.update_needed == 'true' && steps.check-branch.outputs.branch_not_exist == 'true'}}
         run: gh pr create -B main -H ${{ steps.update-go-mod.outputs.branch }} --title "Update Go version to ${{ steps.get-latest-go.outputs.latest_go_version }}" --body "This PR updates the Go version in the go.mod file to the latest available version."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Github Actions workflows were not running when the Github Token was being used to create PRs. The Github Toke needed to be changed into a PAT. 